### PR TITLE
Support all v3 Prettier versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,6 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+# Sample project
+/sample-project/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # prettier-plugin-void-html
 
-This is a [Prettier plugin](https://prettier.io/docs/en/plugins) to format [void HTML elements](https://developer.mozilla.org/en-US/docs/Glossary/Void_element) using the void tag syntax instead of self-closing syntax.
+This is a [Prettier plugin](https://prettier.io/docs/en/plugins) to format [void HTML elements](https://developer.mozilla.org/en-US/docs/Glossary/Void_element) using the void tag syntax instead of self-closing syntax. Additionally, if self-closing syntax is used on non-void elements, then it will be "unwrapped" so that both the opening and closing tags are present.
 
 ## Usage
 
@@ -27,12 +27,54 @@ Then your HTML should format like so:
 <!-- prettier-ignore-start -->
 ```html
 <!-- source -->
-<input name="foobar">
+<meta charset="UTF-8">
+<label for="my-input">Type something</label>
+<input id="my-input" type="text" name="my-input">
+<div />
 
 <!-- Prettier default formatting -->
-<input name="foobar" />
+<meta charset="UTF-8" />
+<label for="my-input">Type something</label>
+<input id="my-input" type="text" name="my-input" />
+<div />
 
 <!-- Prettier + this plugin -->
-<input name="foobar">
+<meta charset="UTF-8">
+<label for="my-input">Type something</label>
+<input id="my-input" type="text" name="my-input">
+<div></div>
 ```
 <!-- prettier-ignore-end -->
+
+## Compatibility
+
+### Prettier
+
+- `v3.0.0`
+- `v3.0.1`
+- `v3.0.2`
+- `v3.0.3`
+- `v3.1.0`
+
+### Languages
+
+- `html`
+
+### Void elements
+
+https://developer.mozilla.org/en-US/docs/Glossary/Void_element
+
+- `area`
+- `base`
+- `br`
+- `col`
+- `embed`
+- `hr`
+- `img`
+- `input`
+- `link`
+- `meta`
+- `param`
+- `source`
+- `track`
+- `wbr`

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,17 @@
       "license": "MIT",
       "devDependencies": {
         "np": "^8.0.4",
-        "prettier": "3.0.3"
+        "prettier-3.0.0": "npm:prettier@3.0.0",
+        "prettier-3.0.1": "npm:prettier@3.0.1",
+        "prettier-3.0.2": "npm:prettier@3.0.2",
+        "prettier-3.0.3": "npm:prettier@3.0.3",
+        "prettier-3.1.0": "npm:prettier@3.1.0"
+      },
+      "engines": {
+        "node": "20.x"
       },
       "peerDependencies": {
-        "prettier": "^3.0.3"
+        "prettier": "3.0.0 - 3.1.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -4234,6 +4241,86 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.3.tgz",
       "integrity": "sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==",
+      "peer": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-3.0.0": {
+      "name": "prettier",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.0.tgz",
+      "integrity": "sha512-zBf5eHpwHOGPC47h0zrPyNn+eAEIdEzfywMoYn2XPi0P44Zp0tSq64rq0xAREh4auw2cJZHo9QUob+NqCQky4g==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-3.0.1": {
+      "name": "prettier",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.1.tgz",
+      "integrity": "sha512-fcOWSnnpCrovBsmFZIGIy9UqK2FaI7Hqax+DIO0A9UxeVoY4iweyaFjS5TavZN97Hfehph0nhsZnjlVKzEQSrQ==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-3.0.2": {
+      "name": "prettier",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.2.tgz",
+      "integrity": "sha512-o2YR9qtniXvwEZlOKbveKfDQVyqxbEIWn48Z8m3ZJjBjcCmUy3xZGIv+7AkaeuaTr6yPXJjwv07ZWlsWbEy1rQ==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-3.0.3": {
+      "name": "prettier",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.3.tgz",
+      "integrity": "sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-3.1.0": {
+      "name": "prettier",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.1.0.tgz",
+      "integrity": "sha512-TQLvXjq5IAibjh8EpBIkNKxO749UEWABoiIZehEPiY4GNpVdhaFKqSTu+QrlU6D2dPAfubRmtJTi4K4YkQ5eXw==",
       "dev": true,
       "bin": {
         "prettier": "bin/prettier.cjs"

--- a/package.json
+++ b/package.json
@@ -37,10 +37,14 @@
   },
   "devDependencies": {
     "np": "^8.0.4",
-    "prettier": "3.0.3"
+    "prettier-3.0.0": "npm:prettier@3.0.0",
+    "prettier-3.0.1": "npm:prettier@3.0.1",
+    "prettier-3.0.2": "npm:prettier@3.0.2",
+    "prettier-3.0.3": "npm:prettier@3.0.3",
+    "prettier-3.1.0": "npm:prettier@3.1.0"
   },
   "peerDependencies": {
-    "prettier": "^3.0.3"
+    "prettier": "3.0.0 - 3.1.0"
   },
   "np": {
     "yarn": false

--- a/prettier-plugin-void-html.js
+++ b/prettier-plugin-void-html.js
@@ -6,6 +6,7 @@ export const languages = [
     name: "HTML5",
     extensions: [".html"],
     parsers: ["html"],
+    vscodeLanguageIds: ["html"],
   },
 ];
 

--- a/test.js
+++ b/test.js
@@ -1,8 +1,15 @@
 import test from "node:test";
 import assert from "node:assert";
-import prettier from "prettier";
 
-const format = async (code) => {
+const allPrettierVersions = await Promise.all([
+  import("prettier-3.0.0"),
+  import("prettier-3.0.1"),
+  import("prettier-3.0.2"),
+  import("prettier-3.0.3"),
+  import("prettier-3.1.0"),
+]);
+
+const format = async (prettier, code) => {
   const output = await prettier.format(code, {
     parser: "html",
     plugins: ["./prettier-plugin-void-html.js"],
@@ -28,47 +35,55 @@ const allVoidElements = [
   "wbr",
 ];
 
-test("preserve void syntax on all void elements", async () => {
-  const results = await Promise.all(
-    allVoidElements.map((el) => format(`<${el}>`)),
-  );
-  results.forEach((formatted, index) => {
-    assert.equal(formatted, `<${allVoidElements[index]}>\n`);
+allPrettierVersions.forEach((dep) => {
+  const { default: prettier, version } = dep;
+
+  test(`Prettier version ${version}`, async (t) => {
+    await t.test("preserve void syntax on all void elements", async () => {
+      const results = await Promise.all(
+        allVoidElements.map((el) => format(prettier, `<${el}>`)),
+      );
+      results.forEach((formatted, index) => {
+        assert.equal(formatted, `<${allVoidElements[index]}>\n`);
+      });
+    });
+
+    await t.test("avoid self-closing syntax on empty elements", async (t) => {
+      await t.test("<div></div>", async () => {
+        const formatted = await format(prettier, `<div></div>`);
+        assert.equal(formatted, `<div></div>\n`);
+      });
+    });
+
+    await t.test("Undo invalid self-closing syntax", async (t) => {
+      await t.test("input", async () => {
+        const formatted = await format(prettier, `<input name="test" />`);
+        assert.equal(formatted, `<input name="test">\n`);
+      });
+
+      await t.test("div", async () => {
+        const formatted = await format(prettier, `<div />`);
+        assert.equal(formatted, `<div></div>\n`);
+      });
+    });
+
+    await t.test("preserve self-closing in SVG", async () => {
+      const formatted = await format(
+        prettier,
+        `<svg><circle cx="50" cy="50" r="50" /></svg>`,
+      );
+      assert.equal(formatted, `<svg><circle cx="50" cy="50" r="50" /></svg>\n`);
+    });
+
+    await t.test("preserve self-closing in MathML", async () => {
+      const formatted = await format(
+        prettier,
+        `<math><mspace depth="40px" height="20px" width="100px" /></math>`,
+      );
+      assert.equal(
+        formatted,
+        `<math><mspace depth="40px" height="20px" width="100px" /></math>\n`,
+      );
+    });
   });
-});
-
-test("avoid self-closing syntax on empty elements", async (t) => {
-  await t.test("<div></div>", async () => {
-    const formatted = await format(`<div></div>`);
-    assert.equal(formatted, `<div></div>\n`);
-  });
-});
-
-test("Undo invalid self-closing syntax", async (t) => {
-  await t.test("input", async () => {
-    const formatted = await format(`<input name="test" />`);
-    assert.equal(formatted, `<input name="test">\n`);
-  });
-
-  await t.test("div", async () => {
-    const formatted = await format(`<div />`);
-    assert.equal(formatted, `<div></div>\n`);
-  });
-});
-
-test("preserve self-closing in SVG", async () => {
-  const formatted = await format(
-    `<svg><circle cx="50" cy="50" r="50" /></svg>`,
-  );
-  assert.equal(formatted, `<svg><circle cx="50" cy="50" r="50" /></svg>\n`);
-});
-
-test("preserve self-closing in MathML", async () => {
-  const formatted = await format(
-    `<math><mspace depth="40px" height="20px" width="100px" /></math>`,
-  );
-  assert.equal(
-    formatted,
-    `<math><mspace depth="40px" height="20px" width="100px" /></math>\n`,
-  );
 });


### PR DESCRIPTION
This PR adds explicit support for all Pretter v3 versions at the time of publishing (up to v3.1.0). The devDependencies were updated to include each version of Prettier, and the tests were updated to iterate over all of them.

The documentation in the README was also updated. Notably, I failed to document previously that non-void self-closing elements are also formatted so that both the opening and closing tags are included. For example, `<div />` becomes `<div></div>`.

Closes #1 