### PR TITLE
Support Prettier v3.2.2 and relax peerDependencies to minor versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ Then your HTML should format like so:
 
 ### Prettier
 
+This package is tested against the following versions of Prettier (see `test.js` for details):
+
 - `v3.0.0`
 - `v3.0.1`
 - `v3.0.2`
@@ -63,6 +65,27 @@ Then your HTML should format like so:
 - `v3.1.1`
 - `v3.2.0`
 - `v3.2.1`
+- `v3.2.2`
+
+Note that the `peerDependencies` of this package allow installing newer _patch versions_ of Prettier that may not be included in this list. This is for pragmatic reasons so that you can upgrade patched releases of Prettier without waiting for this package to update.
+
+However, please note this disclaimer from the [Prettier installation page](https://prettier.io/docs/en/install):
+
+> Install an exact version of Prettier locally in your project. This makes sure that everyone in the project gets the exact same version of Prettier. Even a patch release of Prettier can result in slightly different formatting, so you wouldn’t want different team members using different versions and formatting each other’s changes back and forth.
+
+**If you wish to use a version of Prettier that is not supported by this package**, then you will need to add an [`overrides` rule](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#overrides). For example, to use an older version of Prettier:
+
+```json
+{
+  "overrides": {
+    "@awmottaz/prettier-plugin-void-html": {
+      "prettier": ">=2.8.8"
+    }
+  }
+}
+```
+
+If you do this, please consider [contributing to prettier-plugin-void-html](./CONTRIBUTING.md) by adding tests for that version or [opening an issue](https://github.com/awmottaz/prettier-plugin-void-html/issues). I am happy to expand support, but I also need to be pragmatic of my time.
 
 ### Languages
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "eslint": "8.56.0",
         "eslint-config-prettier": "9.1.0",
         "np": "9.2.0",
-        "prettier": "3.2.1",
+        "prettier": "3.2.2",
         "prettier-3.0.0": "npm:prettier@3.0.0",
         "prettier-3.0.1": "npm:prettier@3.0.1",
         "prettier-3.0.2": "npm:prettier@3.0.2",
@@ -23,13 +23,14 @@
         "prettier-3.1.1": "npm:prettier@3.1.1",
         "prettier-3.2.0": "npm:prettier@3.2.0",
         "prettier-3.2.1": "npm:prettier@3.2.1",
+        "prettier-3.2.2": "npm:prettier@3.2.2",
         "typescript": "5.3.3"
       },
       "engines": {
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "prettier": "3.0.0 - 3.2.1"
+        "prettier": ">=3.0.0 <3.3.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -5232,9 +5233,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.1.tgz",
-      "integrity": "sha512-qSUWshj1IobVbKc226Gw2pync27t0Kf0EdufZa9j7uBSJay1CC+B3K5lAAZoqgX3ASiKuWsk6OmzKRetXNObWg==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.2.tgz",
+      "integrity": "sha512-HTByuKZzw7utPiDO523Tt2pLtEyK7OibUD9suEJQrPUCYQqrHr74GGX6VidMrovbf/I50mPqr8j/II6oBAuc5A==",
       "dev": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
@@ -5363,6 +5364,22 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.1.tgz",
       "integrity": "sha512-qSUWshj1IobVbKc226Gw2pync27t0Kf0EdufZa9j7uBSJay1CC+B3K5lAAZoqgX3ASiKuWsk6OmzKRetXNObWg==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-3.2.2": {
+      "name": "prettier",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.2.tgz",
+      "integrity": "sha512-HTByuKZzw7utPiDO523Tt2pLtEyK7OibUD9suEJQrPUCYQqrHr74GGX6VidMrovbf/I50mPqr8j/II6oBAuc5A==",
       "dev": true,
       "bin": {
         "prettier": "bin/prettier.cjs"

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "typescript": "5.3.3"
   },
   "peerDependencies": {
-    "prettier": "3.0.0 - 3.2.1"
+    "prettier": ">=3.0.0 <3.3.0"
   },
   "np": {
     "yarn": false

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "eslint": "8.56.0",
     "eslint-config-prettier": "9.1.0",
     "np": "9.2.0",
-    "prettier": "3.2.1",
+    "prettier": "3.2.2",
     "prettier-3.0.0": "npm:prettier@3.0.0",
     "prettier-3.0.1": "npm:prettier@3.0.1",
     "prettier-3.0.2": "npm:prettier@3.0.2",
@@ -53,6 +53,7 @@
     "prettier-3.1.1": "npm:prettier@3.1.1",
     "prettier-3.2.0": "npm:prettier@3.2.0",
     "prettier-3.2.1": "npm:prettier@3.2.1",
+    "prettier-3.2.2": "npm:prettier@3.2.2",
     "typescript": "5.3.3"
   },
   "peerDependencies": {

--- a/test.js
+++ b/test.js
@@ -10,6 +10,7 @@ const allPrettierVersions = await Promise.all([
   import("prettier-3.1.1"),
   import("prettier-3.2.0"),
   import("prettier-3.2.1"),
+  import("prettier-3.2.2"),
 ]);
 
 /**


### PR DESCRIPTION
- Adds tested support for Prettier v3.2.2
- Modifies the `peerDependencies` version range of Prettier so that future patch versions are included
    - Given the recent barrage of patch releases from Prettier and the unlikelihood of these breaking this package, I've modified my stance since [writing this comment](https://github.com/awmottaz/prettier-plugin-void-html/issues/7#issuecomment-1857216737).
- Added documentation to the `README` explaining how this package supports Prettier versions

Closes #7 