### PR TITLE
Fix: Void tag followed by any non-whitespace character duplicates closing >

### DIFF
--- a/prettier-plugin-void-html.js
+++ b/prettier-plugin-void-html.js
@@ -48,13 +48,17 @@ const htmlPrinter = {
 
     // Element is not void - use default printer
     if (!node.tagDefinition?.isVoid) {
+      // Prevent forward slash in void tag borrowed end marker
+      if (path.previous?.tagDefinition?.isVoid) {
+        path.previous.isSelfClosing = false;
+      }
+
       return prettierHtmlPrinters.html.print(path, options, print);
     }
 
-    // Then pass it along to the default printer. Since it is no
+    // Pass element along to the default printer. Since it is no
     // longer marked as self-closing, the printer will give it a
     // closing tag. For example, `<input>` will become `<input></input>`.
-
     const printed = prettierHtmlPrinters.html.print(path, options, print);
 
     // The last item in the contents is the new closing tag.
@@ -74,6 +78,8 @@ const htmlPrinter = {
       }
     }
 
+    // Prevent unwanted linebreaks
+    node.isSelfClosing = true;
     return printed;
   },
 };

--- a/prettier-plugin-void-html.js
+++ b/prettier-plugin-void-html.js
@@ -47,8 +47,25 @@ const htmlPrinter = {
     }
 
     if (!node.tagDefinition?.isVoid) {
-      // Not a void tag, use the default printer.
-      return prettierHtmlPrinters.html.print(path, options, print);
+      let printed = prettierHtmlPrinters.html.print(path, options, print);
+
+      // Remove borrowed previous void tag closing marker
+      // @ts-expect-error Property 'prev' does not exist on type 'HtmlNode'
+      if (path.node.prev?.tagDefinition?.isVoid) {
+        if (typeof printed === "string" && printed.startsWith(">"))
+          printed = printed.slice(1);
+        if (
+          isGroup(printed) &&
+          Array.isArray(printed.contents) &&
+          isGroup(printed.contents[0]) &&
+          Array.isArray(printed.contents[0].contents) &&
+          Array.isArray(printed.contents[0].contents[0])
+        ) {
+          printed.contents[0].contents[0].splice(0, 1);
+        }
+      }
+
+      return printed;
     }
 
     // Then pass it along to the default printer. Since it is no

--- a/test.js
+++ b/test.js
@@ -48,7 +48,7 @@ allPrettierVersions.forEach((dep) => {
   const { default: prettier, version } = dep;
 
   test(`Prettier version ${version}`, async (t) => {
-    await t.test("preserve void syntax on all void elements", async () => {
+    await t.test("preserve void syntax on all void elements", async (t) => {
       const results = await Promise.all(
         allVoidElements.map(({ el }) => format(prettier.format, `<${el}>`)),
       );
@@ -58,17 +58,52 @@ allPrettierVersions.forEach((dep) => {
     });
 
     await t.test(
-      "preserve void syntax on all void elements with character following",
+      "preserve void syntax on all void elements with following text",
       async () => {
         const results = await Promise.all(
-          allVoidElements.map(({ el }) => format(prettier.format, `<${el}>a`)),
+          allVoidElements.map(({ el }) =>
+            format(prettier.format, `<${el}>text`),
+          ),
         );
         results.forEach((formatted, index) => {
           const { el, hasTrailingNewline } = allVoidElements[index];
           assert.equal(
             formatted,
-            `<${el}>${hasTrailingNewline ? "\n" : ""}a\n`,
+            `<${el}>${hasTrailingNewline ? "\n" : ""}text\n`,
           );
+        });
+      },
+    );
+
+    await t.test(
+      "preserve void syntax on all void elements with following inline element",
+      async () => {
+        const results = await Promise.all(
+          allVoidElements.map(({ el }) =>
+            format(prettier.format, `<${el}><span></span>`),
+          ),
+        );
+        results.forEach((formatted, index) => {
+          const { el, hasTrailingNewline } = allVoidElements[index];
+          assert.equal(
+            formatted,
+            `<${el}>${hasTrailingNewline ? "\n" : ""}<span></span>\n`,
+          );
+        });
+      },
+    );
+
+    await t.test(
+      "preserve void syntax on all void elements with following block element",
+      async () => {
+        const results = await Promise.all(
+          allVoidElements.map(({ el }) =>
+            format(prettier.format, `<${el}><div></div>`),
+          ),
+        );
+        results.forEach((formatted, index) => {
+          const { el } = allVoidElements[index];
+          assert.equal(formatted, `<${el}>\n<div></div>\n`);
         });
       },
     );
@@ -82,19 +117,13 @@ allPrettierVersions.forEach((dep) => {
 
     await t.test("Undo invalid self-closing syntax", async (t) => {
       await t.test("input", async () => {
-        const formatted = await format(
-          prettier.format,
-          `<input name="test" />`,
+        const results = await Promise.all(
+          allVoidElements.map(({ el }) => format(prettier.format, `<${el} />`)),
         );
-        assert.equal(formatted, `<input name="test">\n`);
-      });
-
-      await t.test("input with character following", async () => {
-        const formatted = await format(
-          prettier.format,
-          `<input name="test" />a`,
-        );
-        assert.equal(formatted, `<input name="test">a\n`);
+        results.forEach((formatted, index) => {
+          const { el } = allVoidElements[index];
+          assert.equal(formatted, `<${el}>\n`);
+        });
       });
 
       await t.test("div", async () => {

--- a/test.js
+++ b/test.js
@@ -116,7 +116,7 @@ allPrettierVersions.forEach((dep) => {
     });
 
     await t.test("Undo invalid self-closing syntax", async (t) => {
-      await t.test("input", async () => {
+      await t.test("void elements", async () => {
         const results = await Promise.all(
           allVoidElements.map(({ el }) => format(prettier.format, `<${el} />`)),
         );

--- a/types/prettier-plugins-html.d.ts
+++ b/types/prettier-plugins-html.d.ts
@@ -6,6 +6,8 @@ type HtmlNode = {
   tagDefinition?: {
     isVoid: boolean;
   };
+  isLeadingSpaceSensitive?: boolean;
+  hasLeadingSpaces?: boolean;
 };
 
 export declare const parsers: {


### PR DESCRIPTION
- Remove void element opening tag end marker (`<br>` → `<br`) if next element borrows it
- Mark void element as `isSelfClosing = true` after printing to prevent parent from adding unwanted line breaks
- When printing non-void element borrowing end marker from void element, mark void element as `isSelfClosing = false` to prevent adding `/>` to void element

Closes #10 